### PR TITLE
Match also Shulker Box content, Enchantments and Potion effects

### DIFF
--- a/fabric/src/main/java/me/lunaluna/find/fabric/widget/FindWidget.java
+++ b/fabric/src/main/java/me/lunaluna/find/fabric/widget/FindWidget.java
@@ -3,6 +3,14 @@ package me.lunaluna.find.fabric.widget;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.widget.TextFieldWidget;
+import net.minecraft.command.argument.RegistryEntryPredicateArgumentType;
+import net.minecraft.component.ComponentMap;
+import net.minecraft.component.DataComponentTypes;
+import net.minecraft.component.type.ContainerComponent;
+import net.minecraft.component.type.ItemEnchantmentsComponent;
+import net.minecraft.component.type.NbtComponent;
+import net.minecraft.component.type.PotionContentsComponent;
+import net.minecraft.enchantment.Enchantment;
 import net.minecraft.entity.effect.StatusEffectInstance;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -10,6 +18,7 @@ import net.minecraft.nbt.NbtCompound;
 import net.minecraft.nbt.NbtElement;
 import net.minecraft.nbt.NbtList;
 import net.minecraft.potion.Potion;
+import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.text.Text;
 import org.apache.logging.log4j.util.Strings;
 import org.jetbrains.annotations.Nullable;
@@ -30,88 +39,64 @@ public class FindWidget extends TextFieldWidget {
         string = string.toLowerCase();
 
         for (String token : text.split(" "))
-            if (! string.contains(token))
+            if (!string.contains(token))
                 return false;
         return true;
     }
 
     public boolean matches(@Nullable ItemStack stack) {
-        try {
-            String text = getText();
-            if (Strings.isBlank(text)) return true;
-            if (stack == null)
-                return false;
-
-            Item item = stack.getItem();
-            if (matchString(item.getName().getString()))
-                return true;
-
-            NbtCompound nbt = stack.getNbt();
-            if (nbt == null)
-                return false;
-
-            for (String key : nbt.getKeys()) {
-                switch (key) {
-                    case "StoredEnchantments":
-                    case "Enchantments":
-                        NbtList enchantmentTag = stack.getNbt().getList(key, 10);
-                        for (int i = 0; i < enchantmentTag.size(); i++) {
-                            NbtCompound nbtTag = enchantmentTag.getCompound(i);
-                            String enchantmentName = nbtTag.getString("id");
-
-                            // Compare the enchantment name to the search text
-                            if (matchString(enchantmentName)) {
-                                return true;
-                            }
-                        }
-                        break;
-                    case "Potion":
-                        NbtElement potionTag = nbt.get(key);
-                        if (potionTag == null)
-                            break;
-                        if (matchString(potionTag.asString()))
-                            return true;
-
-                        Potion potion = Potion.byId(potionTag.asString());
-                        for (StatusEffectInstance effectInstance : potion.getEffects()) {
-                            if (matchString(effectInstance.getEffectType().getName().getString()))
-                                return true;
-                        }
-
-                        break;
-                    case "BlockEntityTag":
-                        NbtCompound blockEntityTag = stack.getSubNbt("BlockEntityTag");
-                        if (blockEntityTag != null && blockEntityTag.contains("Items", 9)) {
-                            NbtList itemList = blockEntityTag.getList("Items", 10);
-                            if (itemList == null)
-                                break;
-
-                            for (int i = 0, len = itemList.size(); i < len; ++i) {
-                                ItemStack s = ItemStack.fromNbt(itemList.getCompound(i));
-                                if (matches(s))
-                                    return true;
-                            }
-
-                        }
-                        break;
-                    default:
-                        // System.out.println(key + ": " + nbt.get(key).toString());
-                }
-
-            }
+        String text = getText();
+        if (Strings.isBlank(text))
+            return true;
+        if (stack == null)
             return false;
-        } catch (Exception e) {
-            e.printStackTrace();
-            return  false;
+
+        Item item = stack.getItem();
+        if (matchString(item.getName().getString()))
+            return true;
+
+        ComponentMap components = stack.getComponents();
+        if (components == null)
+            return false;
+
+        if (components.contains(DataComponentTypes.ENCHANTMENTS)) {
+            ItemEnchantmentsComponent enchantments = components.get(DataComponentTypes.ENCHANTMENTS);
+            for (RegistryEntry<Enchantment> enchantment : enchantments.getEnchantments()) {
+                String enchantmentName = Enchantment.getName(enchantment, enchantments.getLevel(enchantment))
+                        .toString();
+
+                if (matchString(enchantmentName)) {
+                    return true;
+                }
+            }
         }
+        if (components.contains(DataComponentTypes.POTION_CONTENTS)) {
+            PotionContentsComponent potionContents = components.get(DataComponentTypes.POTION_CONTENTS);
+            for (StatusEffectInstance effect : potionContents.getEffects()) {
+                if (matchString(effect.getEffectType().value().getName().toString()))
+                    return true;
+            }
+        }
+        if (components.contains(DataComponentTypes.CONTAINER)) {
+            ContainerComponent container = components.get(DataComponentTypes.CONTAINER);
+            for (ItemStack containedItem : container.iterateNonEmpty()) {
+                if (matches(containedItem))
+                    return true;
+            }
+
+        }
+
+        return false;
     }
 
     @Override
     public boolean mouseClicked(double mouseX, double mouseY, int button) {
-        if (!visible() || !isVisible()) return false;  // Disables mouse clicking when not visible
-        boolean inTextBox = mouseX >= (double)this.getX() && mouseX < (double)(this.getX() + this.width) && mouseY >= (double)this.getY() && mouseY < (double)(this.getY() + this.height);
+        if (!visible() || !isVisible())
+            return false; // Disables mouse clicking when not visible
+        boolean inTextBox = mouseX >= (double) this.getX() && mouseX < (double) (this.getX() + this.width)
+                && mouseY >= (double) this.getY() && mouseY < (double) (this.getY() + this.height);
         if (inTextBox && button == GLFW.GLFW_MOUSE_BUTTON_2) {
-            setText("");  // Clears text on right click
+            setText(""); // Clears text on right click
             return super.mouseClicked(mouseX, mouseY, GLFW.GLFW_MOUSE_BUTTON_1);
         }
         return super.mouseClicked(mouseX, mouseY, button);
@@ -119,7 +104,8 @@ public class FindWidget extends TextFieldWidget {
 
     @Override
     public void render(DrawContext matrices, int mouseX, int mouseY, float delta) {
-        if (visible()) super.render(matrices, mouseX, mouseY, delta);
+        if (visible())
+            super.render(matrices, mouseX, mouseY, delta);
     }
 
     public boolean visible() {

--- a/fabric/src/main/java/me/lunaluna/find/fabric/widget/FindWidget.java
+++ b/fabric/src/main/java/me/lunaluna/find/fabric/widget/FindWidget.java
@@ -3,21 +3,15 @@ package me.lunaluna.find.fabric.widget;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.widget.TextFieldWidget;
-import net.minecraft.command.argument.RegistryEntryPredicateArgumentType;
 import net.minecraft.component.ComponentMap;
 import net.minecraft.component.DataComponentTypes;
 import net.minecraft.component.type.ContainerComponent;
 import net.minecraft.component.type.ItemEnchantmentsComponent;
-import net.minecraft.component.type.NbtComponent;
 import net.minecraft.component.type.PotionContentsComponent;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.entity.effect.StatusEffectInstance;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.NbtCompound;
-import net.minecraft.nbt.NbtElement;
-import net.minecraft.nbt.NbtList;
-import net.minecraft.potion.Potion;
 import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.text.Text;
 import org.apache.logging.log4j.util.Strings;
@@ -61,6 +55,17 @@ public class FindWidget extends TextFieldWidget {
 
         if (components.contains(DataComponentTypes.ENCHANTMENTS)) {
             ItemEnchantmentsComponent enchantments = components.get(DataComponentTypes.ENCHANTMENTS);
+            for (RegistryEntry<Enchantment> enchantment : enchantments.getEnchantments()) {
+                String enchantmentName = Enchantment.getName(enchantment, enchantments.getLevel(enchantment))
+                        .getString();
+
+                if (matchString(enchantmentName)) {
+                    return true;
+                }
+            }
+        }
+        if (components.contains(DataComponentTypes.STORED_ENCHANTMENTS)) {
+            ItemEnchantmentsComponent enchantments = components.get(DataComponentTypes.STORED_ENCHANTMENTS);
             for (RegistryEntry<Enchantment> enchantment : enchantments.getEnchantments()) {
                 String enchantmentName = Enchantment.getName(enchantment, enchantments.getLevel(enchantment))
                         .getString();

--- a/fabric/src/main/java/me/lunaluna/find/fabric/widget/FindWidget.java
+++ b/fabric/src/main/java/me/lunaluna/find/fabric/widget/FindWidget.java
@@ -63,7 +63,7 @@ public class FindWidget extends TextFieldWidget {
             ItemEnchantmentsComponent enchantments = components.get(DataComponentTypes.ENCHANTMENTS);
             for (RegistryEntry<Enchantment> enchantment : enchantments.getEnchantments()) {
                 String enchantmentName = Enchantment.getName(enchantment, enchantments.getLevel(enchantment))
-                        .toString();
+                        .getString();
 
                 if (matchString(enchantmentName)) {
                     return true;
@@ -73,7 +73,7 @@ public class FindWidget extends TextFieldWidget {
         if (components.contains(DataComponentTypes.POTION_CONTENTS)) {
             PotionContentsComponent potionContents = components.get(DataComponentTypes.POTION_CONTENTS);
             for (StatusEffectInstance effect : potionContents.getEffects()) {
-                if (matchString(effect.getEffectType().value().getName().toString()))
+                if (matchString(effect.getEffectType().value().getName().getString()))
                     return true;
             }
         }


### PR DESCRIPTION
I wanted the ability to search for items in shulker boxes. 
So I modified the match function to also match a shulker box if it contains the search item. 
I implemented this by going through the nbt tags, and recursively searching through the Item tags of BlockEtities. This way, BlockEntities with nbt data (like chests)  obtained in creative by control picking the block, also match based on the content.
Based on the suggestion https://github.com/InLieuOfLuna/find/issues/6,
I also match enchantments and potion effects.